### PR TITLE
Remove support for constructor injection and AOP on WebObjects classes

### DIFF
--- a/src/main/java/com/webobjects/foundation/InstantiationInterceptor.java
+++ b/src/main/java/com/webobjects/foundation/InstantiationInterceptor.java
@@ -15,58 +15,23 @@
  */
 package com.webobjects.foundation;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-import java.lang.reflect.Constructor;
-
+import com.google.inject.Injector;
+import com.woinject.InjectableApplication;
+import com.woinject.WOInjectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Binder;
-import com.google.inject.Binding;
-import com.google.inject.BindingAnnotation;
-import com.google.inject.Injector;
-import com.google.inject.Key;
-import com.google.inject.Module;
-import com.google.inject.Provider;
-import com.google.inject.Scopes;
-import com.google.inject.util.Providers;
-import com.webobjects.appserver.WOComponent;
-import com.webobjects.appserver.WODirectAction;
-import com.webobjects.appserver.WOSession;
-import com.webobjects.eocontrol.EOEnterpriseObject;
-import com.woinject.InjectableApplication;
-import com.woinject.WOInjectException;
+import java.lang.reflect.Constructor;
 
 /**
- * The InstantiatorInterceptor class creates objects and injects their members
- * automatically. Special WebObjects types (components, enterprise objects,
- * direct actions and sessions) are instantiated using the Guice injector and
- * are subject to AOP interceptors. This class is private and is not intended to
- * be used directly by users.
- * 
+ * The InstantiatorInterceptor class creates objects and injects their
+ * members (methods and fields only) automatically. This class is private
+ * and is not intended to be used directly by users.
+ *
  * @author <a href="mailto:hprange@gmail.com.br">Henrique Prange</a>
  * @since 1.0
  */
 class InstantiationInterceptor {
-    /**
-     * Special binding annotation used by WOInject to avoid binding conflicts.
-     * 
-     * @author <a href="mailto:hprange@gmail.com.br">Henrique Prange</a>
-     * @since 1.0
-     */
-    @BindingAnnotation
-    @Target({ FIELD, PARAMETER, METHOD })
-    @Retention(RUNTIME)
-    private @interface WOInjectBinding {
-    }
-
     private static final Logger LOGGER = LoggerFactory.getLogger(InstantiationInterceptor.class);
 
     private static <T> Constructor<T> findConstructor(final Class<T> type, final Class<?>[] parameterTypes, boolean shouldThrow, boolean shouldLog) {
@@ -97,17 +62,11 @@ class InstantiationInterceptor {
 
     /**
      * Instantiate the object represented by the type parameter. The object is
-     * created by the injector defined in the {@link InjectableApplication}
-     * class if the type is assignable from <code>WOComponent</code>,
-     * <code>EOEnterpriseObject</code>, <code>WOSession</code> or
-     * <code>WODirectAction</code>.
-     * <p>
-     * Other types of objects are instantiated by reflection, and their members
-     * are injected using the {@link Injector#injectMembers(Object)} method.
-     * Those objects are not subject to AOP interceptors.
-     * 
-     * @see _NSUtilities#instantiateObject(Class, Class[], Object[], boolean,
-     *      boolean)
+     * instantiated by reflection, and their members are injected using the
+     * {@link Injector#injectMembers(Object)} method of the injector defined
+     * in the {@link InjectableApplication} class.
+     *
+     * @see _NSUtilities#instantiateObject(Class, Class[], Object[], boolean, boolean)
      * @see Injector#injectMembers(Object)
      */
     public static <T> T instantiateObject(final Class<T> type, final Class<?>[] parameterTypes, final Object[] parameters, boolean shouldThrow, boolean shouldLog) {
@@ -122,63 +81,25 @@ class InstantiationInterceptor {
 
     /**
      * Instantiate the object represented by the type parameter using the
-     * specified constructor. The object is created by the injector defined in
-     * the {@link InjectableApplication} class if the type is assignable from
-     * <code>WOComponent</code>, <code>EOEnterpriseObject</code>,
-     * <code>WOSession</code> or <code>WODirectAction</code>.
-     * <p>
-     * Other types of objects are instantiated by reflection, and their members
-     * are injected using the {@link Injector#injectMembers(Object)} method.
-     * Those objects are not subject to AOP interceptors.
+     * specified constructor. The object is instantiated by reflection, and
+     * their members are injected using the {@link Injector#injectMembers(Object)}
+     * method of the injector defined in the {@link InjectableApplication} class.
      *
-     * @see _NSUtilities#instantiateObjectWithConstructor(Constructor, Class,
-     *      Object[], boolean, boolean)
+     * @see _NSUtilities#instantiateObjectWithConstructor(Constructor, Class, Object[], boolean, boolean)
      * @see Injector#injectMembers(Object)
      */
     public static <T> T instantiateObjectWithConstructor(final Constructor<T> constructor, final Class<T> type, final Object[] parameters, boolean shouldThrow, boolean shouldLog) {
-        Injector injector = injector();
+        T object = instantiateObjectByReflection(type, constructor, parameters, shouldThrow, shouldLog);
 
-        if (injector == null) {
-            return instantiateObjectByReflection(type, constructor, parameters, shouldThrow, shouldLog);
-        }
+        if (object != null) {
+            Injector injector = injector();
 
-        if (!(WOSession.class.isAssignableFrom(type) || WOComponent.class.isAssignableFrom(type) || EOEnterpriseObject.class.isAssignableFrom(type) || WODirectAction.class.isAssignableFrom(type))) {
-            T object = instantiateObjectByReflection(type, constructor, parameters, shouldThrow, shouldLog);
-
-            if (object != null) {
+            if (injector != null) {
                 injector.injectMembers(object);
             }
-
-            return object;
         }
 
-        Module woinjectModule = new AbstractModule() {
-            @Override
-            @SuppressWarnings({ "rawtypes", "unchecked" })
-            protected void configure() {
-                Binder binder = binder().withSource(type);
-
-                int i = 0;
-
-                if (parameters != null) {
-                    for (Class<?> parameterType : constructor.getParameterTypes()) {
-                        binder.bind(parameterType).toProvider((Provider) Providers.of(parameters[i++]));
-                    }
-                }
-
-                binder.bind(Key.get(type, WOInjectBinding.class)).toConstructor(constructor).in(Scopes.NO_SCOPE);
-            }
-        };
-
-        try {
-            Injector forCreate = injector.createChildInjector(woinjectModule);
-
-            Binding<T> binding = forCreate.getBinding(Key.get(type, WOInjectBinding.class));
-
-            return binding.getProvider().get();
-        } catch (Exception exception) {
-            return handleException(type, exception, shouldThrow, shouldLog);
-        }
+        return object;
     }
 
     private static <T> T instantiateObjectByReflection(Class<T> type, Constructor<T> constructor, Object[] parameters, boolean shouldThrow, boolean shouldLog) {


### PR DESCRIPTION
From the start, WOInject supported constructor injection and AOP for EOs, components, sessions, and direct actions. Since Guice has no support for binding composition at runtime, we've relied on child injectors to manage the instantiation of those objects. As you can imagine, creating child injectors before instantiating every component and EO is not optimal and can severely degrade application performance. Thus, we decided to remove this feature.

This change uses the `injectMembers` method to inject methods and fields annotated with `@Inject` on EOs, components, sessions, and direct actions. Constructor injection and AOP are not supported anymore.